### PR TITLE
Add `cached_staticproperty` and fix `cached_classproperty` in subclasses (fix #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,22 @@ cached_property for class properties instead of instance properties
 ```bash
 pip install cached_classproperty
 ```
+
+## Usage
+
+Similarly to `functools.cached_property`, these properties get executed exactly once on access.
+
+```python
+from cached_classproperty import cached_staticproperty, cached_classproperty
+
+class Foo:
+    @cached_staticproperty
+    def my_staticproperty():
+        ...
+
+    @cached_classproperty
+    def my_classproperty(cls):
+        ...
+```
+
+`cached_classproperty` can be inherited and can re-execute for every inherited class just like `cached_property`. `cached_staticproperty`, on the other hand, executes exactly once even if inherited. It is also lighter and faster than `cached_classproperty`.

--- a/cached_classproperty/__init__.py
+++ b/cached_classproperty/__init__.py
@@ -16,39 +16,103 @@ if TYPE_CHECKING:
     T = TypeVar("T")
     P = ParamSpec("P")
 
-    def cached_classproperty(func: Callable[Concatenate[Any, P], T], attrname: str | None = None) -> T:
+    def cached_staticproperty(
+        func: Callable[Concatenate[P], T], attrname: str | None = None
+    ) -> T:
+        ...
+
+    def cached_classproperty(
+        func: Callable[Concatenate[Any, P], T], attrname: str | None = None
+    ) -> T:
         ...
 
 else:
 
-    class cached_classproperty(cached_property):
-        __slots__ = ("func", "attrname", "__doc__", "lock")
+    class cached_staticproperty:
+        __slots__ = ("func", "attrname", "lock")
 
         def __init__(self, func, attrname: str | None = None):
             self.func = func
             self.attrname = attrname
-            self.__doc__ = func.__doc__
             self.lock = RLock()
 
         def __set_name__(self, owner, name):
+            # Note that this is called at the creation of the class that has cached_staticproperty in its body
+            # but it is not called during inheritance.
             if self.attrname is None:
                 self.attrname = name
             elif name != self.attrname:
                 raise TypeError(
-                    "Cannot assign the same cached_property to two different names "
+                    "Cannot assign the same cached_staticproperty to two different names "
                     f"({self.attrname!r} and {name!r})."
                 )
 
         def __get__(self, instance, owner=None):
             if owner is None:
-                raise TypeError("Cannot use cached_classproperty without an owner class.")
+                raise TypeError(
+                    "Cannot use cached_staticproperty without an owner class."
+                )
             if self.attrname is None:
-                raise TypeError("Cannot use cached_classproperty instance without calling __set_name__ on it.")
-            try:
-                cache = owner.__dict__
-            except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
-                msg = f"No '__dict__' attribute on {owner.__name__!r} " f"to cache {self.attrname!r} property."
-                raise TypeError(msg) from None
+                raise TypeError(
+                    "Cannot use cached_staticproperty instance without calling __set_name__ on it."
+                )
+            # Classes always have __dict__ and metaclasses cannot define __slots__
+            # https://utcc.utoronto.ca/~cks/space/blog/python/HowSlotsWorkI
+            cache = owner.__dict__
+            val = cache.get(self.attrname, _NOT_FOUND)
+            if val is _NOT_FOUND or val is self:
+                with self.lock:
+                    # check if another thread filled cache while we awaited lock
+                    val = cache.get(self.attrname, _NOT_FOUND)
+                    if val is _NOT_FOUND or val is self:
+                        val = self.func()
+                        setattr(owner, self.attrname, val)
+            return val
+
+    class cached_classproperty:
+        __slots__ = ("func", "attrname", "lock", "owner", "_cached_value")
+
+        def __init__(self, func, attrname: str | None = None):
+            self.func = func
+            self.attrname = attrname
+            self.lock = RLock()
+            self.owner = None
+            self._cached_value = _NOT_FOUND
+
+        def __set_name__(self, owner, name):
+            # Note that this is called at the creation of the class that has cached_staticproperty in its body
+            # but it is not called during inheritance.
+            if self.attrname is None:
+                self.attrname = name
+            elif name != self.attrname:
+                raise TypeError(
+                    "Cannot assign the same cached_classproperty to two different names "
+                    f"({self.attrname!r} and {name!r})."
+                )
+            self.owner = owner
+
+        def __get__(self, instance, owner=None):
+            if owner is None:
+                raise TypeError(
+                    "Cannot use cached_classproperty without an owner class."
+                )
+            if self.attrname is None:
+                raise TypeError(
+                    "Cannot use cached_classproperty instance without calling __set_name__ on it."
+                )
+            if owner is not self.owner:
+                new_cached_classproperty = cached_classproperty(
+                    self.func, self.attrname
+                )
+                setattr(owner, self.attrname, new_cached_classproperty)
+                new_cached_classproperty.owner = owner
+                new_cached_classproperty.attrname = self.attrname
+                return getattr(owner, self.attrname)
+            if self._cached_value is not _NOT_FOUND:
+                return self._cached_value
+            # Classes always have __dict__ and metaclasses cannot define __slots__
+            # https://utcc.utoronto.ca/~cks/space/blog/python/HowSlotsWorkI
+            cache = owner.__dict__
             val = cache.get(self.attrname, _NOT_FOUND)
             if val is _NOT_FOUND or val is self:
                 with self.lock:  # type: ignore
@@ -56,5 +120,5 @@ else:
                     val = cache.get(self.attrname, _NOT_FOUND)
                     if val is _NOT_FOUND or val is self:
                         val = self.func(owner)
-                        setattr(owner, self.attrname, val)
+                        self._cached_value = val
             return val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cached_classproperty"
-version = "0.3.0"
+version = "1.0.0"
 description = ""
 authors = ["Stanislav Zmiev <szmiev2000@gmail.com>"]
 license = "MIT"

--- a/tests/test_classproperty.py
+++ b/tests/test_classproperty.py
@@ -1,13 +1,150 @@
-from cached_classproperty import cached_classproperty
+import re
+
+import pytest
+
+from cached_classproperty import cached_classproperty, cached_staticproperty
 
 
-def test_cached_classproperty():
+@pytest.fixture(params=[cached_staticproperty, cached_classproperty])
+def any_cached_property(request):
+    return request.param
+
+
+def test__cached_staticproperty__in_single_class__executes_exactly_once():
     class Foo:
-        @cached_classproperty
-        def bar(cls, times_called=[0]):
+        @cached_staticproperty
+        def bar(times_called=[0]) -> int:
             times_called[0] += 1
             return times_called[0]
 
     assert Foo.bar == 1
+    assert Foo().bar == 1
     assert Foo.bar == 1
+
+
+def test__cached_classproperty__in_single_class__executes_exactly_once():
+    class Foo:
+        @cached_classproperty
+        def bar(cls, times_called=[0]) -> int:
+            times_called[0] += 1
+            return times_called[0]
+
     assert Foo.bar == 1
+    assert Foo().bar == 1
+    assert Foo.bar == 1
+
+
+def test__cached_property__defined_in_two_classes_at_once_with_different_names__should_raise_error(
+    any_cached_property,
+) -> None:
+    @any_cached_property
+    def bar(*args):
+        raise NotImplementedError
+
+    class Foo:
+        foo = bar
+
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            f"Error calling __set_name__ on '{any_cached_property.__name__}' instance 'boo' in 'Bar'"
+        ),
+    ):
+
+        class Bar:
+            boo = bar
+
+
+def test__cached_classproperty__defined_in_two_classes_at_once_with_same_name__should_execute_once_for_each_class():
+    @cached_classproperty
+    def bar(cls, times_called=[0]) -> int:
+        times_called[0] += 1
+        return times_called[0]
+
+    class Foo:
+        foo = bar
+
+    class Bar:
+        foo = bar
+
+    assert Foo.foo == 1
+    assert Bar.foo == 2
+    assert Foo.foo == 1
+    assert Bar.foo == 2
+
+
+def test__cached_staticproperty__defined_in_two_classes_at_once_with_same_name__should_execute_once_for_each_class():
+    @cached_staticproperty
+    def bar(times_called=[0]) -> int:
+        times_called[0] += 1
+        return times_called[0]
+
+    class Foo:
+        foo = bar
+
+    class Bar:
+        foo = bar
+
+    assert Foo.foo == 1
+    assert Bar.foo == 2
+    assert Foo.foo == 1
+    assert Bar.foo == 2
+
+
+def test__cached_staticproperty__when_inherited__executes_exactly_once() -> None:
+    class Foo:
+        @cached_staticproperty
+        def bar(times_called=[0]) -> int:
+            times_called[0] += 1
+            return times_called[0]
+
+    class Baz(Foo):
+        pass
+
+    assert Foo.bar == 1
+    assert Foo().bar == 1
+    assert Foo.bar == 1
+
+    assert Baz.bar == 1
+    assert Baz().bar == 1
+    assert Baz.bar == 1
+
+
+def test__cached_classproperty__when_inherited__behaves_like_classmethod():
+    class Superclass:
+        @classmethod
+        def my_classmethod(cls):
+            return ("Superclass.x",)
+
+        @cached_classproperty
+        def my_cached_classproperty(cls):
+            return cls.my_classmethod()
+
+    class Subclass1(Superclass):
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Subclass1.x",
+            )
+
+    class Subclass2(Superclass):
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Subclass2.x",
+            )
+
+    class Finalclass(Subclass1, Subclass2):
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Finalclass.x",
+            )
+
+    assert Superclass.my_cached_classproperty == Superclass.my_classmethod()
+    assert Subclass1.my_cached_classproperty == Subclass1.my_classmethod()
+    assert Subclass2.my_cached_classproperty == Subclass2.my_classmethod()
+    assert Finalclass.my_cached_classproperty == Finalclass.my_classmethod()

--- a/tests/test_classproperty.py
+++ b/tests/test_classproperty.py
@@ -148,3 +148,61 @@ def test__cached_classproperty__when_inherited__behaves_like_classmethod():
     assert Subclass1.my_cached_classproperty == Subclass1.my_classmethod()
     assert Subclass2.my_cached_classproperty == Subclass2.my_classmethod()
     assert Finalclass.my_cached_classproperty == Finalclass.my_classmethod()
+
+
+def test__cached_classproperty__super():
+    class Superclass:
+        @cached_classproperty
+        def my_cached_classproperty(cls):
+            return ("Superclass",)
+        @classmethod
+        def my_classmethod(cls):
+            return ("Superclass",)
+
+
+    class Subclass1(Superclass):
+        @cached_classproperty
+        def my_cached_classproperty(cls):
+            return (
+                *super().my_cached_classproperty,
+                "Subclass1",
+            )
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Subclass1",
+            )
+
+    class Subclass2(Superclass):
+        @cached_classproperty
+        def my_cached_classproperty(cls):
+            return (
+                *super().my_cached_classproperty,
+                "Subclass2",
+            )
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Subclass2",
+            )
+
+    class Finalclass(Subclass1, Subclass2):
+        @cached_classproperty
+        def my_cached_classproperty(cls):
+            return (
+                *super().my_cached_classproperty,
+                "Finalclass",
+            )
+        @classmethod
+        def my_classmethod(cls):
+            return (
+                *super().my_classmethod(),
+                "Finalclass",
+            )
+
+    assert Superclass.my_cached_classproperty == Superclass.my_classmethod()
+    assert Subclass1.my_cached_classproperty == Subclass1.my_classmethod()
+    assert Finalclass.my_cached_classproperty == Finalclass.my_classmethod()
+    assert Subclass2.my_cached_classproperty == Subclass2.my_classmethod()


### PR DESCRIPTION
This PR is stacked on top of #2, and it takes care of the case where the owner is a subclass of where the property is defined by putting the cached value in a `WeakKeyDictionary`, so that this property would not prevent subclass from being garbage collected.

This PR should fix #1.